### PR TITLE
[BUGFIX] Allow persons with default language in showSelectedAction

### DIFF
--- a/Classes/Domain/Repository/PersonRepository.php
+++ b/Classes/Domain/Repository/PersonRepository.php
@@ -30,6 +30,7 @@ class PersonRepository extends Repository
     {
 
         $query = $this->createQuery();
+        $query->setQuerySettings($query->getQuerySettings()->setRespectSysLanguage(false));
         $ids = GeneralUtility::intExplode(',', $recordList, true);
         if ((bool)$ids) {
             $query->matching($query->in('uid', $ids));

--- a/Configuration/FlexForms/flexform_persons.xml
+++ b/Configuration/FlexForms/flexform_persons.xml
@@ -196,6 +196,16 @@
                                 <type>group</type>
                                 <internal_type>db</internal_type>
                                 <allowed>tx_persons_domain_model_person</allowed>
+                                <fieldControl>
+                                    <elementBrowser>
+                                        <disabled>1</disabled>
+                                    </elementBrowser>
+                                </fieldControl>
+                                <suggestOptions>
+                                    <tx_persons_domain_model_person>
+                                        <searchCondition>sys_language_uid IN (0, -1)</searchCondition>
+                                    </tx_persons_domain_model_person>
+                                </suggestOptions>
                                 <wizards>
                                     <suggest>
                                         <type>suggest</type>

--- a/Tests/Unit/Domain/Repository/PersonRepositoryTest.php
+++ b/Tests/Unit/Domain/Repository/PersonRepositoryTest.php
@@ -16,6 +16,7 @@ namespace CPSIT\Persons\Tests\Unit\Domain\Repository;
 use CPSIT\Persons\Domain\Repository\PersonRepository;
 use Nimut\TestingFramework\TestCase\UnitTestCase;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Persistence\Generic\QuerySettingsInterface;
 use TYPO3\CMS\Extbase\Persistence\QueryInterface;
 use TYPO3\CMS\Extbase\Persistence\RepositoryInterface;
 
@@ -70,10 +71,13 @@ class PersonRepositoryTest extends UnitTestCase
      * @test
      */
     public function findMultipleByUidCreatesAndExecutesQuery() {
+        $querySettings = $this->getMockBuilder(QuerySettingsInterface::class)->getMockForAbstractClass();
+        $querySettings->expects($this->once())->method('setRespectSysLanguage')->with(false)->willReturn($querySettings);
         $mockQuery = $this->getMockBuilder(QueryInterface::class)
-            ->setMethods(['execute'])->getMockForAbstractClass();
+            ->setMethods(['execute', 'getQuerySettings'])->getMockForAbstractClass();
         $this->subject->expects($this->once())->method('createQuery')
             ->will($this->returnValue($mockQuery));
+        $mockQuery->expects($this->once())->method('getQuerySettings')->willReturn($querySettings);
         $mockQuery->expects($this->once())->method('execute');
 
         $this->subject->findMultipleByUid('');
@@ -86,10 +90,14 @@ class PersonRepositoryTest extends UnitTestCase
         $recordList = '3,5,1';
         $recordItems = GeneralUtility::trimExplode(',', $recordList, true);
 
+        $querySettings = $this->getMockBuilder(QuerySettingsInterface::class)->getMockForAbstractClass();
+        $querySettings->expects($this->once())->method('setRespectSysLanguage')->with(false)->willReturn($querySettings);
         $mockQuery = $this->getMockBuilder(QueryInterface::class)
-            ->setMethods(['execute', 'in', 'matching'])->getMockForAbstractClass();
+            ->setMethods(['execute', 'getQuerySettings', 'in', 'matching'])->getMockForAbstractClass();
         $this->subject->expects($this->once())->method('createQuery')
             ->will($this->returnValue($mockQuery));
+
+        $mockQuery->expects($this->once())->method('getQuerySettings')->willReturn($querySettings);
 
         $mockQuery->expects($this->once())
             ->method('in')
@@ -111,10 +119,14 @@ class PersonRepositoryTest extends UnitTestCase
         $orderList = 'foo';
         $orderings = ['foo' => QueryInterface::ORDER_ASCENDING];
 
+        $querySettings = $this->getMockBuilder(QuerySettingsInterface::class)->getMockForAbstractClass();
+        $querySettings->expects($this->once())->method('setRespectSysLanguage')->with(false)->willReturn($querySettings);
         $mockQuery = $this->getMockBuilder(QueryInterface::class)
-            ->setMethods(['execute', 'in', 'matching', 'setOrderings'])->getMockForAbstractClass();
+            ->setMethods(['execute', 'getQuerySettings', 'in', 'matching', 'setOrderings'])->getMockForAbstractClass();
         $this->subject->expects($this->once())->method('createQuery')
             ->will($this->returnValue($mockQuery));
+
+        $mockQuery->expects($this->once())->method('getQuerySettings')->willReturn($querySettings);
 
         $mockQuery->expects($this->once())
             ->method('in')


### PR DESCRIPTION
This patch disables the restriction to the current language in
\CPSIT\Persons\Domain\Repository\PersonRepository::findMultipleByUid
to allow uids from default language that are overlayed afterwards.

Furthermore the plugin FlexForm is changed to hide the element browser
and select person in default language only by using the search box
above the filter.