### PR TITLE
[BUGFIX] Fetch only required property values for FileReferences

### DIFF
--- a/Classes/View/AbstractJsonView.php
+++ b/Classes/View/AbstractJsonView.php
@@ -127,8 +127,9 @@ class AbstractJsonView extends JsonView
             $transformedObject['uri'] = ltrim($this->imageService->getImageUri($processedImage), DIRECTORY_SEPARATOR);
         }
 
-        foreach (ObjectAccess::getGettableProperties($originalResource) as $propertyName => $propertyValue) {
-            if (in_array($propertyName, $configuration)) {
+        foreach ($configuration as $propertyName) {
+            if (ObjectAccess::isPropertyGettable($originalResource, $propertyName)) {
+                $propertyValue = ObjectAccess::getProperty($originalResource, $propertyName);
                 if (is_object($propertyValue)) {
                     $transformedObject[$propertyName] = $this->transformObject($propertyValue, $configuration);
                 } else {


### PR DESCRIPTION
Calling ObjectAccess::getGettableProperties() on a FileReference object
calls getForLocalProcessing() on that object which in return creates
an unused (and orphaned) fal-tempfile- in typo3temp/var/transient/.
As the needed properties are stored in $configuration already it is
valid to iterate over §configuration and get the value with
ObjectAccess::isPropertyGettable() and ObjectAccess::getProperty().