### PR TITLE
[TASK] Add Page Title API support

### DIFF
--- a/Classes/Controller/PersonController.php
+++ b/Classes/Controller/PersonController.php
@@ -17,6 +17,7 @@ use CPSIT\Persons\Domain\Model\Person;
 use CPSIT\Persons\Domain\Repository\PersonRepository;
 use CPSIT\Persons\Event\PersonsHandleFilterBeforeAssignEvent;
 use CPSIT\Persons\Event\PersonsHandleListBeforeAssignEvent;
+use CPSIT\Persons\Seo\TitleProvider;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Configuration\Exception\InvalidConfigurationTypeException;
@@ -65,6 +66,7 @@ class PersonController extends ActionController
      */
     public function showAction(Person $person): void
     {
+        GeneralUtility::makeInstance(TitleProvider::class)->setPerson($person);
         $this->view->assign('person', $person);
     }
 

--- a/Classes/Seo/TitleProvider.php
+++ b/Classes/Seo/TitleProvider.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CPSIT\Persons\Seo;
+
+/***
+ *
+ * This file is part of the "Persons" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ *  (c) 2023 Daniel Siepmann <coding@daniel-siepmann.de>
+ *
+ ***/
+
+use CPSIT\Persons\Domain\Model\Person;
+use TYPO3\CMS\Core\PageTitle\AbstractPageTitleProvider;
+
+class TitleProvider extends AbstractPageTitleProvider
+{
+    private ?Person $person = null;
+
+    public function setPerson(Person $person): void
+    {
+        $this->person = $person;
+        $this->title = $person->getFirstName() . ' ' . $person->getLastName();
+    }
+}

--- a/Documentation/Configuration/TypoScript.md
+++ b/Documentation/Configuration/TypoScript.md
@@ -81,3 +81,15 @@ plugin.tx_persons {
 ```
   
 ## TypoScript Controller / Page Type
+
+## Page Title
+
+Use provided title provider.
+
+```typo3_typoscript
+config.pageTitleProviders {
+    record {
+        provider = CPSIT\Persons\Seo\TitleProvider
+    }
+}
+```

--- a/Tests/Unit/Seo/TitleProviderTest.php
+++ b/Tests/Unit/Seo/TitleProviderTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CPSIT\Persons\Tests\Unit\Seo;
+
+/***
+ *
+ * This file is part of the "Persons" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ *  (c) 2023 Daniel Siepmann <coding@daniel-siepmann.de>
+ *
+ ***/
+
+use CPSIT\Persons\Domain\Model\Person;
+use CPSIT\Persons\Seo\TitleProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \CPSIT\Persons\Seo\TitleProvider
+ */
+final class TitleProviderTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function canBeCreated(): void
+    {
+        $subject = new TitleProvider();
+
+        self::assertInstanceOf(
+            TitleProvider::class,
+            $subject
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function returnsDefaultTitle(): void
+    {
+        $person = $this->createMock(Person::class);
+        $person->method('getFirstName')->willReturn('John');
+        $person->method('getLastName')->willReturn('Doe');
+
+        $subject = new TitleProvider();
+        $subject->setPerson($person);
+
+        self::assertSame('John Doe', $subject->getTitle());
+    }
+
+    /**
+     * @test
+     */
+    public function returnsFallbackIfPersonWasNotSet(): void
+    {
+        $subject = new TitleProvider();
+
+        self::assertSame('', $subject->getTitle());
+    }
+}


### PR DESCRIPTION
A new Page Title Provider is added that receives the Person on show action.
A default title will be defined based on first name and last name. The class can be exchanged by project specific installations in order to alter the title generation.

Resolves: #11